### PR TITLE
Fix typo in file selection comment

### DIFF
--- a/DataBladeAnalysis v7.py
+++ b/DataBladeAnalysis v7.py
@@ -47,7 +47,7 @@ from OCC.Core.gp import gp_Pnt
 # - Mach Distribution file
 # Others to be determined when checking other files
 
-# --------------------------- FILES SLECTION ---------------------------
+# --------------------------- FILE SELECTION ---------------------------
 
 bladeName = "blade" #Change this name depending on the blade you want to study
 no_cores = 12 # Change this to switch the processing power of the computation (numbers of used cores)

--- a/DataBladeAnalysis v8.py
+++ b/DataBladeAnalysis v8.py
@@ -47,7 +47,7 @@ from OCC.Core.gp import gp_Pnt
 # - Mach Distribution file
 # Others to be determined when checking other files
 
-# --------------------------- FILES SLECTION ---------------------------
+# --------------------------- FILE SELECTION ---------------------------
 
 bladeName = "blade" #Change this name depending on the blade you want to study
 no_cores = 12 # Change this to switch the processing power of the computation (numbers of used cores)


### PR DESCRIPTION
## Summary
- correct the comment heading for file selection in the analysis scripts

## Testing
- `python -m py_compile "DataBladeAnalysis v7.py" "DataBladeAnalysis v8.py"`

------
https://chatgpt.com/codex/tasks/task_e_684040fb5c14832e91b05035bf52f1b6